### PR TITLE
Docs 2 (#10)

### DIFF
--- a/ClaimIntro.md
+++ b/ClaimIntro.md
@@ -1,0 +1,6 @@
+# Claims
+
+The framework can be used to define _claims_ (also called requirements or tests) to verify the the model is accurate and describes the security posture of the system.
+
+This features is very much under development.
+Please, take a look of modules `tcsfw.default_requirements` and `tcsfw.etsi_ts_103_701` to see the claims and tests used in the research publications.

--- a/CommandLine.md
+++ b/CommandLine.md
@@ -2,10 +2,10 @@
 
 This document goes through some command-line options for the [tcsfw](README.md).
 
-As default, the loaded model is printed out. Consider the following, which prints out the samplem model `iot-a`.
+As default, the loaded model is printed out. Consider the following, which prints out the samplem model "Basic A".
 
 ```
-$ python samples/iot-a/system.py
+$ python samples/basic-a/system.py
 ```
 
 ## Command-line help
@@ -21,12 +21,12 @@ $ python tcsfw/main.py --help
 Coverage for default requirements (called _claims_ or _tests_ in research papers) can be checked like this:
 
 ```
-$ python samples/iot-a/system.py --output coverage
+$ python samples/basic-a/system.py --output coverage
 ```
 
 The used specification can be changed from the default. Currently the only one is `etsi-ts-103-701`.
 
 ```
-$ python samples/iot-a/system.py --output coverage:etsi-ts-103-701
+$ python samples/basic-a/system.py --output coverage:etsi-ts-103-701
 ```
 

--- a/DSLIntro.md
+++ b/DSLIntro.md
@@ -1,0 +1,52 @@
+# Short DSL intro
+
+The framework uses _Domain Specific Language_ (DSL) to describe the system model.
+The DSL is based on Python 3 programming language.
+The following assumes basic understanding of the Python language.
+
+## DSL essentials
+
+Consider the following very simple model called "Basic a".
+The model is in file `samples/basic-a/system.py`.
+
+```python
+from tcsfw.main import Builder, TLS
+
+system = Builder.new("Basic A")
+device = system.device()
+backend = system.backend().serve()
+app = system.mobile()
+
+device >> backend / TLS
+app >> backend / TLS
+```
+
+The model building start with call to `Builder.new`, which takes the name of the system as argument, and returns to system object.
+The system comprises IoT _device_, _backend_ service, and a mobile _application_, called together network _nodes_. 
+The device and the application connect to the backend using TLS-protected _connections_.
+
+## Graphical view
+
+A visual representation of a model requires placing the network nodes into canvas.
+The positions are controlled using DSL, like below.
+
+```python
+system.visualize().place(
+    "D   A",
+    "  B  ",
+) .where({
+    "D": device,
+    "B": backend,
+    "A": app
+})
+```
+
+The letters "A", "B", and "C" stand for the application, backend, and device.
+Thei positions are determined in the `place` method.
+
+## DSL reference
+
+The interface code for the DSL is in Python module `tcsfw.main`.
+DSLs can use definitions from `tcsfw.basics`, as well.
+The source code in these files provides for the authorative reference code.
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ The functionality of the framework is now reading output of several different "s
 
 Before use, you must [install](Install.md) the framework from _Github_.
 
-The project contains security statement for _Ruuvi gateway and tags_ (https://ruuvi.com/) which is used in the research. The statement is in directory `samples/ruuvi/`. The data for verifying the security statement is available for academic research, please request it from Rauli. Remember to tell the goals of the research and the organization performing it. Right to refuse requests is reserved.
+The framework comes with sample security stateuments in directory `samples/`. The security statements descriptin are in a [Domain Specific Language (DSL)](DSLIntro.md).
+The description of the claims also employs [a DSL](ClaimIntro.md), but that is very much unmature at the moment.
+
+The one used in the research is the security statement for _Ruuvi gateway and tags_ (https://ruuvi.com/) which is used in the research. The statement is in directory `samples/ruuvi/`. The data for verifying the security statement is available for academic research, please request it from Rauli. Remember to tell the goals of the research and the organization performing it. Right to refuse requests is reserved.
 
 Security statements are described by Python-based DSLs. A description is executable Python script. The security statement for Ruuvi is executed like this, assuming working directory is the project root:
 ```

--- a/samples/basic-a/system.py
+++ b/samples/basic-a/system.py
@@ -1,16 +1,14 @@
-import tcsfw
 from tcsfw.main import Builder, TLS
-from tcsfw.traffic import IPFlow
 
-system = Builder.new("IoT A")
+system = Builder.new("Basic A")
 device = system.device()
-backend = system.backend().serve(TLS(auth=True))
+backend = system.backend().serve(TLS)
 app = system.mobile()
 
 device >> backend / TLS
 app >> backend / TLS
 
-# Visualization
+# Graphical view
 system.visualize().place(
     "D   A",
     "  B  ",

--- a/tcsfw/basics.py
+++ b/tcsfw/basics.py
@@ -1,0 +1,60 @@
+import enum
+
+
+class HostType(enum.Enum):
+    """Host types"""
+    GENERIC = ""               # default, assumed plaintext data
+    DEVICE = "Device"          # local device
+    MOBILE = "Mobile"          # mobile (application)
+    REMOTE = "Remote"          # remote, youngsters call it "cloud"
+    BROWSER = "Browser"        # browser, user selected and installed
+    ADMINISTRATIVE = "Admin"   # administration, match ConnectionType
+
+
+class ConnectionType(enum.Enum):
+    """Connection types"""
+    UNKNOWN = ""               # default, assumed plaintext data
+    ENCRYPTED = "Encrypted"    # strong encryption
+    ADMINISTRATIVE = "Admin"   # administration, no private data
+    LOGICAL = "Logical"        # only a logical connection
+
+
+class ExternalActivity(enum.IntEnum):
+    """External activity levels"""
+    BANNED = 0                 # no external activity allowed
+    PASSIVE = 1                # passive, probing ok but no replies
+    OPEN = 2                   # external use of open services ok
+    UNLIMITED = 3              # unlimited activity, including client connections
+
+
+class Verdict(enum.Enum):
+    """Verdict for entity, connection, property, etc."""
+    INCON = "Incon"                # Inconclusive check
+    FAIL = "Fail"                  # Failed check
+    PASS = "Pass"                  # All checks pass
+    IGNORE = "Ignore"              # Ignore
+
+    @classmethod
+    def update(cls, *verdicts: 'Verdict') -> 'Verdict':
+        """Update verdict for property, etc. Ignore overrides all others."""
+        if not verdicts:
+            return Verdict.INCON
+        if len(verdicts) == 1:
+            return verdicts[0]
+        v_set = set(verdicts)
+        for s in [Verdict.IGNORE, Verdict.FAIL, Verdict.PASS, Verdict.INCON]:
+            if s in v_set:
+                return s
+        raise NotImplementedError(f"Cannot update {verdicts}")
+
+    @classmethod
+    def aggregate(cls, *verdicts: 'Verdict') -> 'Verdict':
+        """Resolve aggregate verdict for entity from child verdicts, never return ignore."""
+        if not verdicts:
+            return Verdict.INCON
+        v_set = set(verdicts)
+        for s in [Verdict.FAIL, Verdict.PASS]:
+            if s in v_set:
+                return s
+        return Verdict.INCON
+

--- a/tcsfw/coverage_result.py
+++ b/tcsfw/coverage_result.py
@@ -198,7 +198,7 @@ class CoverageReport:
             if status.authority in {ClaimAuthority.MODEL, ClaimAuthority.TOOL}:
                 return "-"
             return "."
-        if status.verdict == Verdict.PASS:
+        if stGatewayatus.verdict == Verdict.PASS:
             if status.authority in {ClaimAuthority.MODEL, ClaimAuthority.TOOL}:
                 return "X"
             return "x"

--- a/tcsfw/main.py
+++ b/tcsfw/main.py
@@ -1,16 +1,11 @@
-import argparse
-import io
-import ipaddress
-import itertools
-import json
-import logging
-import pathlib
-import sys
-
 from typing import Any, Callable, Dict, List, Optional, Self, Tuple, Type, Union
 from tcsfw.address import HWAddress, HWAddresses, IPAddress, IPAddresses
 from tcsfw.selector import RequirementSelector
 from tcsfw.basics import ConnectionType, HostType, Verdict, ExternalActivity
+
+
+ProtocolType = Union['ProtocolConfigurer', Type['ProtocolConfigurer']]
+ServiceOrGroup = Union['ServiceBuilder', 'ServiceGroupBuilder']
 
 
 class SystemBuilder:
@@ -66,26 +61,6 @@ class SystemBuilder:
 
     def claims(self, base_label="explain") -> 'ClaimSetBuilder':
         raise NotImplementedError()
-
-
-# Host types
-BROWSER = HostType.BROWSER
-
-# Connection types
-ADMINISTRATIVE = ConnectionType.ADMINISTRATIVE
-ENCRYPTED = ConnectionType.ENCRYPTED
-PLAINTEXT = ConnectionType.UNKNOWN
-
-
-# External activity
-BANNED = ExternalActivity.BANNED
-PASSIVE = ExternalActivity.PASSIVE
-OPEN = ExternalActivity.OPEN
-UNLIMITED = ExternalActivity.UNLIMITED
-
-
-ProtocolType = Union['ProtocolConfigurer', Type['ProtocolConfigurer']]
-ServiceOrGroup = Union['ServiceBuilder', 'ServiceGroupBuilder']
 
 
 class NodeBuilder:
@@ -463,7 +438,6 @@ class Builder:
     def TCP(cls, source_hw: str, source_ip: str, port: int) -> 'FlowBuilder':
         """Create a new TCP flow"""
         return FlowBuilder("TCP", (HWAddress.new(source_hw), IPAddress.new(source_ip), port))
-
 
 if __name__ == "__main__":
     Builder.new().run()

--- a/tests/test_dhcp.py
+++ b/tests/test_dhcp.py
@@ -4,7 +4,7 @@ from tcsfw.basics import Verdict
 from tcsfw.builder_backend import SystemBackend
 from tcsfw.event_logger import EventLogger
 from tcsfw.inspector import Inspector
-from tcsfw.main import UNLIMITED, DHCP, UDP
+from tcsfw.main import DHCP, UDP
 from tcsfw.matcher import SystemMatcher
 from tcsfw.pcap_reader import PCAPReader
 from tcsfw.traffic import IPFlow

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,9 +1,9 @@
-from tcsfw.basics import Verdict
+from tcsfw.basics import ExternalActivity, Verdict
 from tcsfw.builder_backend import SystemBackend
 import test_model
 from tcsfw.address import EndpointAddress, Protocol, IPAddress
 from tcsfw.inspector import Inspector
-from tcsfw.main import DHCP, ICMP, UDP, TCP, UNLIMITED
+from tcsfw.main import DHCP, UDP, TCP
 from tcsfw.traffic import IPFlow, Evidence, EvidenceSource, ServiceScan, HostScan
 from tcsfw.verdict import Status
 
@@ -68,7 +68,7 @@ def test_irrelevant_traffic():
     sb = SystemBackend()
     dev1 = sb.device().hw("1:0:0:0:0:1")
     dev2 = sb.device().ip("192.168.0.2")
-    dev2.external_activity(UNLIMITED)
+    dev2.external_activity(ExternalActivity.UNLIMITED)
     dev1 >> dev2 / UDP(port=1234)
     i = Inspector(sb.system)
 
@@ -121,7 +121,7 @@ def test_scan():
 def test_foreign_connection():
     sb = test_model.simple_setup_1()
     dev2 = sb.system.get_endpoint(IPAddress.new("192.168.0.2"))
-    dev2.set_external_activity(UNLIMITED)
+    dev2.set_external_activity(ExternalActivity.UNLIMITED)
     i = Inspector(sb.system)
 
     # target is known service


### PR DESCRIPTION
* First sentences. No writer block \o/

* TCSFW_SERVICE_API_KEY now

* More documentation

* Prefix blackduck-

* Tools documentation started, first three tools

* Do not log each skipped file in non-data directory

* Now github-releases

* Adding more tool-descriptions

* File type 'http', not 'web-link'

* Completed entry-level version of tool documentation

* Ruuvi GW serves DHCP

* Use __repr__, not __str__

* First list printed

* Log event may have implicit and explicit properties

* One claim builder with same label

* Explain why not all properties show

* Verify connection encryption for target endpoint

* Always verdict for property in client API

* Fix for __repr__ in EthernetFlow

* Fix connection is_relevant logic

* Avoid timing attack in token comparison

* Evidence filtering logic improvements

* Removed non-determinism in verdict aggregation

* Reset model properties int INCON if they have verdict values

* Query parameters through WS get. Allow to disable initial model load

* Avoid non-relevant connections in API in model reload

* Evidence label is a string

* Filter evidence sources by labels, as many sources may share the same label

* Run normally even when logging events

* Testssl more careful properties

* Unified property events at Testssl and Ssh-audit

* Removed dead entity coverage

* More reliably get source tool for property

* Missing Optional

* StatusClaim and related properties are dead

* Tool name is the explanation for a property by planned tool

* Fixed class name

* Tool planning to claims. Group planned tools properly

* Installation instructions

* Removed stypid constants

* IoT A is now Basic A

* DSL documentation started

* Basic A model name fix and remove TLS auth

* Document graphical view

* Link DSL intro from README

* Use the source as reference, Luke

* Cleaned bad import from basic-a

* Placeholder for Claim DSL description